### PR TITLE
Fix: env var exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Compliance-Framework Infrastructure Example
 
-
-
 This project helps setting up infrastructure for local development.
 
 It could be considered an example deployment as opposed to actually part of the working code.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Compliance-Framework Infrastructure Example
 
+
+
 This project helps setting up infrastructure for local development.
 
 It could be considered an example deployment as opposed to actually part of the working code.
@@ -76,11 +78,13 @@ This brings up the pods and services that make up the CF cluster, and the persis
 
 9. (Optional) Install [k9s](https://k9scli.io/)
 
-10. Run the demo script
+10. (Optional, for `ga` command below) Install [asciigraph](https://github.com/guptarohit/asciigraph)
+
+11. Run the demo script
 
 `./demo.sh`
 
-11. Interact with the demo script
+12. Interact with the demo script
 
 You can run the various commands to interact with the server, eg
 

--- a/hack/ssh_setup.sh
+++ b/hack/ssh_setup.sh
@@ -5,16 +5,17 @@ set -euo pipefail
 src_folder="$(pwd)/${0%/*}"
 cd $src_folder
 
-source ../.env
+source ../.env 
 
 echo "____________________________________________________________"
 echo "Running CF setup for SSH plugin"
 
 # Refer to the vars to be sure they exist
-CF_SSH_USERNAME=$CF_SSH_USERNAME
-CF_SSH_PASSWORD=$CF_SSH_PASSWORD
-CF_SSH_HOST=$CF_SSH_HOST
-CF_SSH_COMMAND=$CF_SSH_COMMAND
+export CF_SSH_USERNAME=$CF_SSH_USERNAME
+export CF_SSH_PASSWORD=$CF_SSH_PASSWORD
+export CF_SSH_HOST=$CF_SSH_HOST
+export CF_SSH_COMMAND=$CF_SSH_COMMAND
+export CF_SSH_PORT=${CF_SSH_PORT:-"22"}
 
 echo "Creating Plan: Sample Assessment Plan"
 while true

--- a/hack/ssh_setup.sh
+++ b/hack/ssh_setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 src_folder="$(pwd)/${0%/*}"
 cd $src_folder
 
-source ../.env 
+source ../.env
 
 echo "____________________________________________________________"
 echo "Running CF setup for SSH plugin"

--- a/hack/ssh_setup_activity.yaml
+++ b/hack/ssh_setup_activity.yaml
@@ -10,7 +10,7 @@ provider:
       password: $CF_SSH_PASSWORD
       host: $CF_SSH_HOST
       command: $CF_SSH_COMMAND
-      port: 2227
+      port: $CF_SSH_PORT
 subjects:
   title: Server
   description: "Server: '$CF_SSH_HOST'"


### PR DESCRIPTION
Sourcing `.env`  was not enough for `envsubt` to use the variables. This exports them, and also sets `22` as a default port if not provided.