### PR TITLE
Update compose commands to use current directory

### DIFF
--- a/hack/local-shared/do
+++ b/hack/local-shared/do
@@ -1,38 +1,39 @@
 #!/bin/bash
 
 COMPOSE_COMMAND="${COMPOSE_COMMAND:-podman-compose}"
+CWD=$(pwd)
 
 start_common() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/ui.yml up -d
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/ui.yml up -d
 }
 
 start_api() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml up -d
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml up -d
 }
 
 start_agents() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/agent-local-ssh.yml up -d
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/agent-local-ssh.yml up -d
 }
 
 start_all() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml -f compose/demo-agents.yml up -d
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml -f ${CWD}/compose/demo-agents.yml up -d
 }
 
 stop() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml -f compose/demo-agents.yml down
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml -f ${CWD}/compose/demo-agents.yml down
 }
 
 destroy() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml -f compose/demo-agents.yml down -v
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml -f ${CWD}/compose/demo-agents.yml down -v
 }
 
 pull() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml -f compose/demo-agents.yml pull
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml -f ${CWD}/compose/demo-agents.yml pull
 }
 
 # Run is the default function. No need to call its name.
 run() {
-    ${COMPOSE_COMMAND} -f compose/common.yml -f compose/api.yml -f compose/ui.yml -f compose/demo-agents.yml "$@"
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/api.yml -f ${CWD}/compose/ui.yml -f ${CWD}/compose/demo-agents.yml "$@"
 }
 
 # Check if the function exists

--- a/hack/local-shared/do
+++ b/hack/local-shared/do
@@ -12,7 +12,7 @@ start_api() {
 }
 
 start_agents() {
-    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/agent-local-ssh.yml up -d
+    ${COMPOSE_COMMAND} -f ${CWD}/compose/common.yml -f ${CWD}/compose/demo-agents.yml up -d
 }
 
 start_all() {


### PR DESCRIPTION
* Hack commands started failing due to using the script directory as it's base. We want to use the users working directory as the base to make commands obvious. This PR makes sure that happens